### PR TITLE
test: add false positive postinstall script

### DIFF
--- a/tests/legacy-cli/e2e/tests/misc/check-postinstalls.ts
+++ b/tests/legacy-cli/e2e/tests/misc/check-postinstalls.ts
@@ -16,6 +16,7 @@ const FALSE_POSITIVE_PATHS: ReadonlySet<string> = new Set([
   'jasmine-spec-reporter/examples/protractor/package.json',
   'resolve/test/resolver/multirepo/package.json',
   'resolve/test/list-exports/packages/tests/fixtures/resolve-1/project/test/resolver/multirepo/package.json',
+  'resolve/test/list-exports/packages/tests/fixtures/resolve-2/project/test/resolver/multirepo/package.json',
 ]);
 
 const INNER_NODE_MODULES_SEGMENT = '/node_modules/';


### PR DESCRIPTION
`resolve/test/list-exports/packages/tests/fixtures/resolve-2/project/test/resolver/multirepo/package.json` is not a true postinstall script

